### PR TITLE
Minor updates

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -5,12 +5,12 @@
 |===
 |WildFly Release | Java EE Version
 
-|link:12[12.0.0.Final]
-|https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and partial EE8 Preview)]
-|link:13[13.0.0.Final]
-|https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and full EE8 Preview)]
 |link:14[14.0.0.Final]
 |https://docs.oracle.com/javaee/8/api/toc.htm[Java EE 8]
+|link:13[13.0.0.Final]
+|https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and full EE8 Preview)]
+|link:12[12.0.0.Final]
+|https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and partial EE8 Preview)]
 
 |===
 

--- a/index.adoc
+++ b/index.adoc
@@ -6,7 +6,7 @@
 |WildFly Release | Java EE Version
 
 |link:14[14.0.0.Final]
-|https://docs.oracle.com/javaee/8/api/toc.htm[Java EE 8]
+|https://javaee.github.io/javaee-spec/javadocs[Java EE 8]
 |link:13[13.0.0.Final]
 |https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and full EE8 Preview)]
 |link:12[12.0.0.Final]


### PR DESCRIPTION
The first commit just reorders the releases from newest to oldest. Not sure if that's the way we want it, but once the list grows it just seemed the best option.

The second commit fixes the 404 for the Java EE 8 documentation.