### PR TITLE
[#35] Refactor entry page to reduce number of current WildFly releases

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -9,6 +9,35 @@
 |https://jakarta.ee/specifications/platform/8/apidocs/[Jakarta EE 8]
 |
 
+|===
+
+|===
+|Bootable JAR
+
+|link:bootablejar[5.0.1.Final]
+
+|===
+
+|===
+|Galleon
+
+|link:galleon[4.2.4.Final]
+
+|===
+
+|===
+|WildFly Galleon Plug-ins
+
+|link:galleon-plugins[4.0.3.Final]
+
+|===
+
+
+== WildFly Previous Releases
+
+|===
+|WildFly Release | Jakarta EE Version | Java EE Version
+
 |link:23[23.0.0.Final]
 |https://jakarta.ee/specifications/platform/8/apidocs/[Jakarta EE 8]
 |
@@ -64,26 +93,5 @@
 |link:12[12.0.0.Final]
 |
 |https://docs.oracle.com/javaee/7/api/toc.htm[Java EE 7 (and partial EE8 Preview)]
-
-|===
-
-|===
-|Bootable JAR
-
-|link:bootablejar[5.0.1.Final]
-
-|===
-
-|===
-|Galleon
-
-|link:galleon[4.2.4.Final]
-
-|===
-
-|===
-|WildFly Galleon Plug-ins
-
-|link:galleon-plugins[4.0.3.Final]
 
 |===


### PR DESCRIPTION
Just one possibility, I've moved the WildFly Server previous releases to the bottom 

Fixes #35 