### PR TITLE
Fix broken internal links

### DIFF
--- a/12/Admin_Guide.html
+++ b/12/Admin_Guide.html
@@ -16844,9 +16844,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -16977,7 +16977,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/13/Admin_Guide.html
+++ b/13/Admin_Guide.html
@@ -17428,9 +17428,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -17561,7 +17561,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/14/Admin_Guide.html
+++ b/14/Admin_Guide.html
@@ -17716,9 +17716,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -17849,7 +17849,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/15/Admin_Guide.html
+++ b/15/Admin_Guide.html
@@ -17855,9 +17855,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -17988,7 +17988,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/16/Admin_Guide.html
+++ b/16/Admin_Guide.html
@@ -18166,9 +18166,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -18299,7 +18299,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/17/Admin_Guide.html
+++ b/17/Admin_Guide.html
@@ -18249,9 +18249,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -18382,7 +18382,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/18/Admin_Guide.html
+++ b/18/Admin_Guide.html
@@ -18499,9 +18499,9 @@ JVM.</p></td>
 <p>WildFly binds sockets to the IP addresses and interfaces contained in
 the <code>&lt;interfaces&gt;</code> elements in <code>standalone.xml</code>, <code>domain.xml</code> and
 <code>host.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-interfaces">Interfaces</a>
+<a href="Admin_Guide.html#Interfaces_and_ports">Interfaces</a>
 and
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard
 configurations that ship with WildFly includes two interface
 configurations:</p>
@@ -18632,7 +18632,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/19.1/Admin_Guide.html
+++ b/19.1/Admin_Guide.html
@@ -19403,7 +19403,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/19/Admin_Guide.html
+++ b/19/Admin_Guide.html
@@ -19388,7 +19388,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/20/Admin_Guide.html
+++ b/20/Admin_Guide.html
@@ -19415,7 +19415,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/21/Admin_Guide.html
+++ b/21/Admin_Guide.html
@@ -19590,7 +19590,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/22/Admin_Guide.html
+++ b/22/Admin_Guide.html
@@ -20114,7 +20114,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/23/Admin_Guide.html
+++ b/23/Admin_Guide.html
@@ -20742,7 +20742,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/24/Admin_Guide.html
+++ b/24/Admin_Guide.html
@@ -20767,7 +20767,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/25/Admin_Guide.html
+++ b/25/Admin_Guide.html
@@ -18880,7 +18880,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/26.1/Admin_Guide.html
+++ b/26.1/Admin_Guide.html
@@ -19183,7 +19183,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>

--- a/26/Admin_Guide.html
+++ b/26/Admin_Guide.html
@@ -19003,7 +19003,7 @@ your configuration to ignore them.</p>
 those involving high availability clustering. The multicast addresses
 and ports used are configured using the <code>socket-binding</code> elements in
 <code>standalone.xml</code> and <code>domain.xml</code>. (See
-<a href="General_configuration_concepts.html#src-557065_Generalconfigurationconcepts-socket-bindings">Socket
+<a href="Admin_Guide.html#socket-bindings-and-socket-binding-groups">Socket
 Bindings</a> for further information on these elements.) The standard HA
 configurations that ship with WildFly include two socket binding
 configurations that use a default multicast address:</p>


### PR DESCRIPTION
Link is fixed in the sektion "Controlling the Default Multicast Address with -u" and " Controlling the Bind Address with -b"

In older version of the docs the link points to https://docs.jboss.org/author/display/WFLY/General%20configuration%20concepts.html and https://docs.jboss.org/author/display/WFLY/General%20configuration%20concepts.html