### PR TITLE
[WFLY-18202] Fix the broken landing page WildFly logo link for 28 and 27

### DIFF
--- a/27/index.html
+++ b/27/index.html
@@ -463,7 +463,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="preamble">
 <div class="sectionbody">
 <div class="paragraph">
-<p><span class="image"><img src="splash_wildflylogo_small.png" alt="WildFly"></span></p>
+<p><span class="image"><img src="images/splash_wildflylogo_small.png" alt="WildFly"></span></p>
 </div>
 <div class="paragraph">
 <p>Welcome to the WildFly documentation. The documentation for WildFly is

--- a/28/index.html
+++ b/28/index.html
@@ -463,7 +463,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="preamble">
 <div class="sectionbody">
 <div class="paragraph">
-<p><span class="image"><img src="splash_wildflylogo_small.png" alt="WildFly"></span></p>
+<p><span class="image"><img src="images/splash_wildflylogo_small.png" alt="WildFly"></span></p>
 </div>
 <div class="paragraph">
 <p>Welcome to the WildFly documentation. The documentation for WildFly is


### PR DESCRIPTION
For this JIRA for WildFly 29 I fixed a whole lot of other broken links. Fixing all those for previous versions is more than I have time to do, but at least I can improve the landing pages.

https://issues.redhat.com/browse/WFLY-18202