### PR TITLE
add link to Helm Chart and Operator doc from index page

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -39,6 +39,13 @@
 
 |===
 
+|===
+|Helm Chart for WildFly
+
+|link:wildfly-charts[Documentation]
+
+|===
+
 == WildFly Previous Releases
 
 |===

--- a/index.adoc
+++ b/index.adoc
@@ -39,10 +39,14 @@
 
 |===
 
-|===
-|Helm Chart for WildFly
+[[wildfly-on-kubernetes]]
+== Build and Deploy WildFly on Kubernetes
 
-|link:wildfly-charts[Documentation]
+|===
+|Tools to build and deploy WildFly on Kubernetes
+
+|link:wildfly-charts[Helm Chart for WildFly]
+|link:wildfly-operator[Kubernetes Operator for WildFly]
 
 |===
 

--- a/index.html
+++ b/index.html
@@ -519,6 +519,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </tbody>
 </table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Helm Chart for WildFly</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="wildfly-charts">Documentation</a></p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect1">
@@ -645,7 +660,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-07-24 17:43:11 +0100
+Last updated 2023-09-06 11:16:25 +0200
 </div>
 </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -519,18 +519,26 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="wildfly-on-kubernetes">Build and Deploy WildFly on Kubernetes</h2>
+<div class="sectionbody">
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Helm Chart for WildFly</th>
+<th class="tableblock halign-left valign-top">Tools to build and deploy WildFly on Kubernetes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="wildfly-charts">Documentation</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="wildfly-charts">Helm Chart for WildFly</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="wildfly-operator">Kubernetes Operator for WildFly</a></p></td>
 </tr>
 </tbody>
 </table>
@@ -660,7 +668,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-09-06 11:16:25 +0200
+Last updated 2023-09-06 14:15:21 +0200
 </div>
 </div>
 </body>


### PR DESCRIPTION
The doc for wildfly-charts is published from the https://github.com/wildfly/wildfly-charts repository
using GitHub pages.
Documentation is already live at https://docs.wildfly.org/wildfly-charts/

Documentation is generated from the https://github.com/wildfly/wildfly-operator repository
and publishing with GitHub pages.
Documentation is alreary live at http://docs.wildfly.org/wildfly-operator/

Put the Helm Chart and Operator in their own section separated from the Releases