### PR TITLE
HAPROXY configuration: add "check" keyword

### DIFF
--- a/36/High_Availability_Guide.html
+++ b/36/High_Availability_Guide.html
@@ -2469,8 +2469,8 @@ backend myservers
 mode http
 cookie SRV indirect preserve
 option redispatch
-server server1 127.0.0.1:8080 cookie ribera1
-server server2 127.0.0.1:8180 cookie ribera2</code></pre>
+server server1 127.0.0.1:8080 check cookie ribera1
+server server2 127.0.0.1:8180 check cookie ribera2</code></pre>
 </div>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
In e.g. https://www.haproxy.com/blog/enable-sticky-sessions-in-haproxy the `check cookie` is used: @pferraro should we add that here?